### PR TITLE
fix error action creator

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -23,14 +23,6 @@ function createActionCreators (options) {
     const argsCreator = argsCreatorByType[type]
     const payloadCreator = (cid, ...args) => argsCreator(...args)
     const actionCreator = createAction(actionTypes[type], payloadCreator, metaCreator)
-    // HACK because @f/create-action doesn't do this already
-    if (type === 'error') {
-      return (...args) => {
-        var action = actionCreator(...args)
-        action.error = true
-        return action
-      }
-    }
     return actionCreator
   }
 }

--- a/test/actions.js
+++ b/test/actions.js
@@ -76,7 +76,6 @@ test('request error', function (t) {
   const expectedAction = {
     type: actionTypes.error,
     payload: err,
-    error: true,
     meta: {
       cid
     }


### PR DESCRIPTION
no longer have `error: true` property on returned action.