### PR TITLE
only export methods + complete unless internal = true

### DIFF
--- a/action-types.js
+++ b/action-types.js
@@ -16,23 +16,25 @@ module.exports = createActionTypes
 function createActionTypes (options) {
   const {
     service,
+    internal = false,
     methods = DEFAULT_METHODS
   } = options
 
   const createActionType = ActionType(service)
 
-  return merge(
-    getActionTypesForMethods(createActionType, methods),
-    {
-      set: createActionType(['set']),
-      setAll: createActionType(['setAll']),
-      unset: createActionType(['unset']),
-      unsetAll: createActionType(['unsetAll']),
-      start: createActionType(['start']),
-      complete: createActionType(['complete']),
-      error: createActionType(['error'])
-    }
-  )
+  const internalTypes = {
+    set: createActionType(['set']),
+    setAll: createActionType(['setAll']),
+    unset: createActionType(['unset']),
+    unsetAll: createActionType(['unsetAll']),
+    start: createActionType(['start']),
+    complete: createActionType(['complete']),
+    error: createActionType(['error'])
+  }
+  const externalTypes = getActionTypesForMethods(createActionType, methods)
+
+  if (internal) return merge(externalTypes, internalTypes)
+  else return merge(externalTypes, { complete: internalTypes.complete })
 }
 
 const ActionType = (service) => {

--- a/epic.js
+++ b/epic.js
@@ -25,7 +25,7 @@ function createEpic (options) {
   } = options
 
   const actionTypes = createActionTypes(options)
-  const actionCreators = createActionCreators(options)
+  const actionCreators = createActionCreators(merge(options, { internal: true }))
 
   const epics = createEpics({ actionTypes, actionCreators, service })
   return combineEpics(...values(epics))

--- a/test/action-types.js
+++ b/test/action-types.js
@@ -3,7 +3,7 @@ const test = require('tape')
 const createActionTypes = require('../action-types')
 
 test('returns the service action ids', function (t) {
-  const actionTypes = createActionTypes({ service: 'cats' })
+  const actionTypes = createActionTypes({ service: 'cats', internal: true })
 
   t.equal(actionTypes.find, 'FEATHERS_CATS_FIND')
   t.equal(actionTypes.get, 'FEATHERS_CATS_GET')

--- a/test/actions.js
+++ b/test/actions.js
@@ -7,8 +7,8 @@ const { all, has, __ } = require('ramda')
 const createModule = require('../')
 const createActionTypes = require('../action-types')
 
-const cats = createModule('cats')
-const actionTypes = createActionTypes({ service: 'cats' })
+const cats = createModule({ service: 'cats', internal: true })
+const actionTypes = createActionTypes({ service: 'cats', internal: true })
 
 test('action creators have correct keys', function (t) {
   const keys = ['find', 'create', 'get', 'update', 'patch', 'remove', 'set', 'start', 'complete', 'error']

--- a/test/epic.js
+++ b/test/epic.js
@@ -17,7 +17,7 @@ const createModule = require('../')
 
 const service = 'cats'
 const cats = createModule({ service })
-const actionCreators = createActionCreators({ service })
+const actionCreators = createActionCreators({ service, internal: true })
 
 var currentCid = 100
 function createCid () {

--- a/updater.js
+++ b/updater.js
@@ -7,6 +7,7 @@ const pipe = require('ramda/src/pipe')
 const reduce = require('ramda/src/reduce')
 const __ = require('ramda/src/__')
 const { withDefaultState, concat, updateStateAt, handleActions, decorate } = require('redux-fp')
+const merge = require('ramda/src/merge')
 
 const createActionTypes = require('./action-types')
 
@@ -15,7 +16,7 @@ module.exports = createUpdater
 function createUpdater (options) {
   const { service } = options
 
-  const actionTypes = createActionTypes(options)
+  const actionTypes = createActionTypes(merge(options, { internal: true }))
 
   return concat(
     createServiceUpdater(actionTypes, service),


### PR DESCRIPTION
why?

- makes sense to not return actions that shouldn't be used anyways
- need special handling of `complete` in `feathers-action-react`, feels better if it's special already (as in the only exported action that isn't a method call), maybe